### PR TITLE
Remove ACL parameter from S3 upload - configure public access via buc…

### DIFF
--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -37,7 +37,8 @@ export class S3Service {
                     Key: key,
                     Body: file,
                     ContentType: contentType,
-                    ACL: "public-read", // Explicitly set ACL for public access
+                    // Removed ACL parameter - modern S3 buckets often have ACLs disabled
+                    // Public access should be configured via bucket policy instead
                 },
             });
 


### PR DESCRIPTION
https://github.com/craftlabstech/craft/issues/8
This pull request makes a small update to the `S3Service` class in `lib/s3.ts` by removing the `ACL` parameter from S3 upload calls. The change reflects best practices for modern S3 buckets, where ACLs are often disabled and public access is managed via bucket policies instead.